### PR TITLE
Restrict IAM permissions by AWS account, not region

### DIFF
--- a/terraform/lambda-role-policy.json
+++ b/terraform/lambda-role-policy.json
@@ -7,7 +7,7 @@
         "logs:CreateLogGroup"
       ],
       "Resource": [
-        "arn:aws:logs:${aws_region}:${aws_account}:log-group:/aws/lambda/${app_name}-${app_env}*:*"
+        "arn:aws:logs:*:${aws_account}:log-group:/aws/lambda/${app_name}-${app_env}*:*"
       ],
       "Effect": "Allow"
     },
@@ -16,7 +16,7 @@
         "logs:PutLogEvents"
       ],
       "Resource": [
-        "arn:aws:logs:${aws_region}:${aws_account}:log-group:/aws/lambda/${app_name}-${app_env}*:*:*"
+        "arn:aws:logs:*:${aws_account}:log-group:/aws/lambda/${app_name}-${app_env}*:*:*"
       ],
       "Effect": "Allow"
     },

--- a/terraform/lambda-role-policy.json
+++ b/terraform/lambda-role-policy.json
@@ -34,7 +34,7 @@
         "dynamodb:Scan",
         "dynamodb:GetItem"
       ],
-      "Resource": "arn:aws:dynamodb:${aws_region}:*:table/${api_key_table}",
+      "Resource": "arn:aws:dynamodb:*:${aws_account}:table/${api_key_table}",
       "Effect": "Allow"
     },
     {
@@ -47,7 +47,7 @@
         "dynamodb:UpdateItem",
         "dynamodb:DeleteItem"
       ],
-      "Resource": "arn:aws:dynamodb:${aws_region}:*:table/${webauthn_table}",
+      "Resource": "arn:aws:dynamodb:*:${aws_account}:table/${webauthn_table}",
       "Effect": "Allow"
     }
   ]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -34,7 +34,6 @@ resource "aws_iam_role" "lambdaRole" {
 data "template_file" "lambdaRolePolicy" {
   template = file("${path.module}/lambda-role-policy.json")
   vars = {
-    aws_region     = var.aws_region
     aws_account    = var.aws_account_id
     app_name       = var.app_name
     app_env        = var.app_env

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,7 +15,7 @@ module "serverless-user" {
 
 // Create role for lambda function
 resource "aws_iam_role" "lambdaRole" {
-  name = "${var.app_name}-${var.app_env}-${var.aws_region}-lambdaRole"
+  name = "${var.app_name}-${var.app_env}-lambdaRole"
 
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",


### PR DESCRIPTION
### Changed (non-breaking)
- Stop limiting `logs` permissions by region
- Limit `dynamodb` permissions by account, not region
- Remove unused `aws_region` var from lambdaRolePolicy
- Remove region from lambdaRole name