### PR TITLE
Fix lamda role name details

### DIFF
--- a/local.env.example
+++ b/local.env.example
@@ -16,7 +16,7 @@ FRONTEND2_DOMAIN=
 
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
-LAMBDA_ROLE=arn:aws:iam::123456789012:role/twosv-api-prod-us-east-1-lambdaRole
+LAMBDA_ROLE=arn:aws:iam::123456789012:role/twosv-api-prod-lambdaRole
 API_KEY_TABLE=mfa-api_prod_api-key
 WEBAUTHN_TABLE=mfa-api_prod_u2f
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,7 @@
 */
 module "serverless-user" {
   source  = "silinternational/serverless-user/aws"
-  version = "0.3.1"
+  version = "0.3.2"
 
   app_name           = "${var.app_name}-${var.app_env}"
   aws_region         = var.aws_region


### PR DESCRIPTION
### Fixed
- Fix example `LAMBDA_ROLE` to not include the region name
- Use updated serverless-user module to support role name without region