### PR TITLE
Add DNS records and custom domains for easy cross-region failover

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,6 +13,20 @@ module "serverless-user" {
   extra_policies     = var.extra_policies
 }
 
+// Set up custom domain name for easier fail-over.
+module "dns_for_failover" {
+  source = "github.com/silinternational/terraform-aws-serverless-api-dns-for-failover?ref=0.2.0"
+
+  app_name             = var.app_name
+  cloudflare_zone_name = var.cloudflare_zone_name
+  serverless_stage     = var.app_env
+
+  providers = {
+    aws           = aws
+    aws.secondary = aws.secondary
+  }
+}
+
 // Create role for lambda function
 resource "aws_iam_role" "lambdaRole" {
   name = "${var.app_name}-${var.app_env}-lambdaRole"

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -30,3 +30,7 @@ provider "aws" {
 
   alias = "secondary"
 }
+
+provider "cloudflare" {
+  api_token = var.cloudflare_token
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,15 +1,32 @@
+
+locals {
+  tags = {
+    managed_by        = "terraform"
+    workspace         = terraform.workspace
+    itse_app_customer = var.app_customer
+    itse_app_env      = var.app_environment
+    itse_app_name     = var.app_name_tag
+  }
+}
+
 provider "aws" {
   region     = var.aws_region
   access_key = var.aws_access_key_id
   secret_key = var.aws_secret_access_key
 
   default_tags {
-    tags = {
-      managed_by        = "terraform"
-      workspace         = terraform.workspace
-      itse_app_customer = var.app_customer
-      itse_app_env      = var.app_environment
-      itse_app_name     = var.app_name_tag
-    }
+    tags = local.tags
   }
+}
+
+provider "aws" {
+  region     = var.aws_region_secondary
+  access_key = var.aws_access_key_id
+  secret_key = var.aws_secret_access_key
+
+  default_tags {
+    tags = local.tags
+  }
+
+  alias = "secondary"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,8 +20,13 @@ variable "aws_account_id" {
 }
 
 variable "aws_region" {
+  description = "Primary AWS region where this lambda will be deployed"
   type        = string
-  description = "A valid AWS region where this lambda will be deployed"
+}
+
+variable "aws_region_secondary" {
+  description = "Secondary AWS region where this lambda will be deployed"
+  type        = string
 }
 
 variable "aws_secret_access_key" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -83,6 +83,16 @@ variable "create_webauthn_table" {
   default = true
 }
 
+variable "cloudflare_token" {
+  description = "The Cloudflare limited access API token"
+  type        = string
+}
+
+variable "cloudflare_zone_name" {
+  description = "Cloudflare zone (domain) for DNS records"
+  type        = string
+}
+
 /*
  * AWS tag values
  */


### PR DESCRIPTION
### Changed (BREAKING)
- Add required `aws_region_secondary` variable, for use by serverless-api-dns-for-failover module
- Add required Cloudflare variables, for use by serverless-api-dns-for-failover module

### Added
- Use `serverless-api-dns-for-failover` module to add custom domains and a DNS record for easy failover
- Add AWS provider for secondary region
- Add cloudflare provider