### PR TITLE
Provide correct API Name to dns-for-failover module

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,11 +15,12 @@ module "serverless-user" {
 
 // Set up custom domain name for easier fail-over.
 module "dns_for_failover" {
-  source = "github.com/silinternational/terraform-aws-serverless-api-dns-for-failover?ref=0.2.0"
+  source = "github.com/silinternational/terraform-aws-serverless-api-dns-for-failover?ref=feature%2Fdo-not-assume-api-name-follows-pattern"
 
-  app_name             = var.app_name
+  api_name             = "${var.app_name}-${var.app_env}"
   cloudflare_zone_name = var.cloudflare_zone_name
   serverless_stage     = var.app_env
+  subdomain            = var.app_name
 
   providers = {
     aws           = aws


### PR DESCRIPTION
### Fixed
- Provide correct API Name to dns-for-failover terraform module