### PR TITLE
Change Cloudflare zone/domain name variable

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,7 +18,7 @@ module "dns_for_failover" {
   source = "github.com/silinternational/terraform-aws-serverless-api-dns-for-failover?ref=0.3.0"
 
   api_name             = "${var.app_name}-${var.app_env}"
-  cloudflare_zone_name = var.cloudflare_zone_name
+  cloudflare_zone_name = var.cloudflare_domain
   serverless_stage     = var.app_env
   subdomain            = var.app_name
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -88,7 +88,7 @@ variable "cloudflare_token" {
   type        = string
 }
 
-variable "cloudflare_zone_name" {
+variable "cloudflare_domain" {
   description = "Cloudflare zone (domain) for DNS records"
   type        = string
 }


### PR DESCRIPTION
### Fixed
- Change variable `cloudflare_zone_name` to `cloudflare_domain` for consistency and because our Terraform Cloud variable set uses the variable name `cloudflare_domain`.
