### PR TITLE
HOTFIX: Preemptively grant IAM permissions

### DIFF
--- a/terraform/lambda-role-policy.json
+++ b/terraform/lambda-role-policy.json
@@ -7,7 +7,7 @@
         "logs:CreateLogGroup"
       ],
       "Resource": [
-        "arn:aws:logs:${aws_region}:${aws_account}:log-group:/aws/lambda/${app_name}-${app_env}*:*"
+        "arn:aws:logs:*:${aws_account}:log-group:/aws/lambda/${app_name}-${app_env}*:*"
       ],
       "Effect": "Allow"
     },
@@ -16,7 +16,7 @@
         "logs:PutLogEvents"
       ],
       "Resource": [
-        "arn:aws:logs:${aws_region}:${aws_account}:log-group:/aws/lambda/${app_name}-${app_env}*:*:*"
+        "arn:aws:logs:*:${aws_account}:log-group:/aws/lambda/${app_name}-${app_env}*:*:*"
       ],
       "Effect": "Allow"
     },

--- a/terraform/lambda-role-policy.json
+++ b/terraform/lambda-role-policy.json
@@ -34,7 +34,10 @@
         "dynamodb:Scan",
         "dynamodb:GetItem"
       ],
-      "Resource": "arn:aws:dynamodb:*:${aws_account}:table/${api_key_table}",
+      "Resource": [
+        "arn:aws:dynamodb:*:${aws_account}:table/${api_key_table}",
+        "arn:aws:dynamodb:*:${aws_account}:table/${api_key_table}_global"
+      ],
       "Effect": "Allow"
     },
     {
@@ -47,7 +50,10 @@
         "dynamodb:UpdateItem",
         "dynamodb:DeleteItem"
       ],
-      "Resource": "arn:aws:dynamodb:*:${aws_account}:table/${webauthn_table}",
+      "Resource": [
+        "arn:aws:dynamodb:*:${aws_account}:table/${webauthn_table}",
+        "arn:aws:dynamodb:*:${aws_account}:table/${webauthn_table}_global"
+      ],
       "Effect": "Allow"
     }
   ]

--- a/terraform/lambda-role-policy.json
+++ b/terraform/lambda-role-policy.json
@@ -34,7 +34,7 @@
         "dynamodb:Scan",
         "dynamodb:GetItem"
       ],
-      "Resource": "arn:aws:dynamodb:${aws_region}:*:table/${api_key_table}",
+      "Resource": "arn:aws:dynamodb:*:${aws_account}:table/${api_key_table}",
       "Effect": "Allow"
     },
     {
@@ -47,7 +47,7 @@
         "dynamodb:UpdateItem",
         "dynamodb:DeleteItem"
       ],
-      "Resource": "arn:aws:dynamodb:${aws_region}:*:table/${webauthn_table}",
+      "Resource": "arn:aws:dynamodb:*:${aws_account}:table/${webauthn_table}",
       "Effect": "Allow"
     }
   ]


### PR DESCRIPTION
## WARNING:
This is a PR directly to `main`, via a `hotfix` branch based off of `main`, because we are not yet ready to release some of the other changes already in `develop`.

---

### Added
- Preemptively grant access to the "..._global" DynamoDB tables 
  * After finishing the migration to global tables and updating the `api_key_table` and `webauthn_table` Terraform variables to include that "_global" suffix in their values, we will be able to revert this single commit, to clean things back up. We just need this for a smoother migration.

### Changed (non-breaking)
- Limit `dynamodb` permissions by AWS account, not region
- Stop limiting `logs` permissions by region

---

The primary reason for this is the "Added" item above. In order to do that while (hopefully) avoiding merge conflicts later, I included the other changes to that file as well (using git's "cherry pick" feature, so the changes are exact).