### PR TITLE
Use updated CNAMEs for failover (with some related bugfixes)

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,7 +21,7 @@ module "serverless-user" {
 // Set up custom domain name for easier fail-over.
 module "dns_for_failover" {
   source  = "silinternational/serverless-api-dns-for-failover/aws"
-  version = "0.4.0"
+  version = "~>0.5.1"
 
   api_name             = local.api_name
   cloudflare_zone_name = var.cloudflare_domain


### PR DESCRIPTION
### Changed (non-breaking)
- Use updated CNAMEs for failover (with some related bugfixes)

---

Release notes for serverless-api-dns-for-failover are here:
https://github.com/silinternational/terraform-aws-serverless-api-dns-for-failover/releases