### PR TITLE
Remove the duplicate "..._global" resource from IAM policy

### DIFF
--- a/terraform/lambda-role-policy.json
+++ b/terraform/lambda-role-policy.json
@@ -35,8 +35,7 @@
         "dynamodb:GetItem"
       ],
       "Resource": [
-        "arn:aws:dynamodb:*:${aws_account}:table/${api_key_table}",
-        "arn:aws:dynamodb:*:${aws_account}:table/${api_key_table}_global"
+        "arn:aws:dynamodb:*:${aws_account}:table/${api_key_table}"
       ],
       "Effect": "Allow"
     },
@@ -51,8 +50,7 @@
         "dynamodb:DeleteItem"
       ],
       "Resource": [
-        "arn:aws:dynamodb:*:${aws_account}:table/${webauthn_table}",
-        "arn:aws:dynamodb:*:${aws_account}:table/${webauthn_table}_global"
+        "arn:aws:dynamodb:*:${aws_account}:table/${webauthn_table}"
       ],
       "Effect": "Allow"
     }


### PR DESCRIPTION
### Fixed
- Remove the duplicate "..._global" resource from the Lambda Role's policy

---

The `api_key_table` and `webauthn_table` values now include the full table name, so this transitional additional resource name (where we manually appended the "_global" suffix) is no longer needed.