### PR TITLE
return key handle hash from login endpoint

### DIFF
--- a/webauthn.go
+++ b/webauthn.go
@@ -121,7 +121,8 @@ func FinishLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := map[string]string{
-		"credentialId": string(credential.ID),
+		"credentialId":    string(credential.ID),
+		"key_handle_hash": hashAndEncodeKeyHandle(credential.ID),
 	}
 
 	jsonResponse(w, resp, http.StatusOK)

--- a/webauthn.go
+++ b/webauthn.go
@@ -42,6 +42,11 @@ type finishRegistrationResponse struct {
 	KeyHandleHash string `json:"key_handle_hash"`
 }
 
+type finishLoginResponse struct {
+	CredentialID  string `json:"credentialId"` // DEPRECATED, use KeyHandleHash instead
+	KeyHandleHash string `json:"key_handle_hash"`
+}
+
 func BeginRegistration(w http.ResponseWriter, r *http.Request) {
 	user, err := getUserFromContext(r)
 	if err != nil {
@@ -120,9 +125,9 @@ func FinishLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := map[string]string{
-		"credentialId":    string(credential.ID),
-		"key_handle_hash": hashAndEncodeKeyHandle(credential.ID),
+	resp := finishLoginResponse{
+		CredentialID:  string(credential.ID),
+		KeyHandleHash: hashAndEncodeKeyHandle(credential.ID),
 	}
 
 	jsonResponse(w, resp, http.StatusOK)

--- a/webauthn_test.go
+++ b/webauthn_test.go
@@ -583,9 +583,11 @@ func (ms *MfaSuite) Test_FinishLogin() {
 	// Give user two different credentials to see them come through
 	const credID1 = "11345678-1234-1234-1234-123456789012"
 	credIDEncoded1 := base64.StdEncoding.EncodeToString([]byte(credID1))
+	khh1 := hashAndEncodeKeyHandle([]byte(credID1))
 
 	const credID2 = "22345678-1234-1234-1234-123456789012"
 	credIDEncoded2 := base64.StdEncoding.EncodeToString([]byte(credID2))
+	khh2 := hashAndEncodeKeyHandle([]byte(credID2))
 
 	const challenge = "W8GzFU8pGjhoRbWrLDlamAfq_y4S1CZG1VuoeRLARrE"
 
@@ -688,6 +690,7 @@ func (ms *MfaSuite) Test_FinishLogin() {
 			httpReq: reqWithBody1,
 			wantBodyContains: []string{
 				`"credentialId":"` + credID1 + `"`,
+				`"key_handle_hash":"` + khh1 + `"`,
 			},
 		},
 		{
@@ -695,6 +698,7 @@ func (ms *MfaSuite) Test_FinishLogin() {
 			httpReq: reqWithBody2,
 			wantBodyContains: []string{
 				`"credentialId":"` + credID2 + `"`,
+				`"key_handle_hash":"` + khh2 + `"`,
 			},
 		},
 	}


### PR DESCRIPTION
### Added
- Return the hash of the key handle, which is what the registration endpoint returns. This allows the caller to look up the credential by the same token that it had at registration time.