### PR TITLE
hide demo-ui from linguist

### DIFF
--- a/mfa/.gitattributes
+++ b/mfa/.gitattributes
@@ -1,0 +1,1 @@
+demo-ui/** linguist-detectable=false


### PR DESCRIPTION
### Added
- Added .gitattributes file to hide `demo-ui` folder from linguist (improve repo language)