### PR TITLE
use the provided.al2 Lambda runtime due to go1.x deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Serverless directories
 .serverless
 
-# golang output binary directory
-bin
+# Go output binary
+bootstrap
 
 # docker config file
 dockercfg

--- a/codeship/build.sh
+++ b/codeship/build.sh
@@ -6,5 +6,5 @@ set -e
 # Echo out all commands for monitoring progress
 set -x
 
-# Build the binaries
+# When using the provided.al2 runtime, the binary must be named "bootstrap" and be in the root directory
 CGO_ENABLED=0 go build -tags lambda.norpc -ldflags="-s -w" -o bootstrap ./lambda

--- a/codeship/build.sh
+++ b/codeship/build.sh
@@ -7,4 +7,4 @@ set -e
 set -x
 
 # Build the binaries
-go build -ldflags="-s -w" -o bin/webauthn ./lambda
+CGO_ENABLED=0 go build -tags lambda.norpc -ldflags="-s -w" -o bootstrap ./lambda

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: ^3.7
 
 provider:
   name: aws
-  runtime: go1.x
+  runtime: provided.al2
   timeout: 5 # API Gateway invoked functions are limited to 30 seconds
   versionFunctions: false
   logRetentionInDays: 14
@@ -33,11 +33,11 @@ custom:
 package:
   patterns:
     - '!./**'
-    - './bin/**'
+    - './bootstrap'
 
 functions:
   webauthn:
-    handler: bin/webauthn
+    handler: bootstrap
     events:
       - http:
           path: '{webauthn+}'


### PR DESCRIPTION
### Changed
- Use the Amazon Linux 2 Lambda runtime due to the deprecation of the go1.x runtime

[ITSE-756](https://itse.youtrack.cloud/issue/ITSE-756)