### PR TITLE
Release - Run golangci-lint and govulncheck in CI workflow

### DIFF
--- a/.github/workflows/test-deploy-publish.yml
+++ b/.github/workflows/test-deploy-publish.yml
@@ -23,6 +23,26 @@ jobs:
       - name: Test
         run: docker compose -f actions-services.yml run --rm test ./scripts/test.sh
 
+  lint:
+    name: Lint and Vulnerability Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ fromJSON(vars.DEFAULT_JOB_TIMEOUT_MINUTES) }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        check-latest: true
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: latest
+        working-directory: application
+    - name: govulncheck
+      run: |
+        go install golang.org/x/vuln/cmd/govulncheck@latest
+        govulncheck -C application ./...
+
   deploy:
     name: Deploy to AWS Lambda
     needs: tests

--- a/.github/workflows/test-deploy-publish.yml
+++ b/.github/workflows/test-deploy-publish.yml
@@ -44,7 +44,7 @@ jobs:
 
   deploy:
     name: Deploy to AWS Lambda
-    needs: tests
+    needs: [ 'tests', 'lint' ]
     if: github.ref_name == 'main' || github.ref_name == 'develop'
     runs-on: ubuntu-latest
     strategy:
@@ -71,7 +71,7 @@ jobs:
 
   build-and-publish:
     name: Build and Publish
-    needs: tests
+    needs: [ 'tests', 'lint' ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/test-deploy-publish.yml
+++ b/.github/workflows/test-deploy-publish.yml
@@ -37,7 +37,6 @@ jobs:
       uses: golangci/golangci-lint-action@v6
       with:
         version: latest
-        working-directory: application
     - name: govulncheck
       run: |
         go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/test-deploy-publish.yml
+++ b/.github/workflows/test-deploy-publish.yml
@@ -40,7 +40,7 @@ jobs:
     - name: govulncheck
       run: |
         go install golang.org/x/vuln/cmd/govulncheck@latest
-        govulncheck -C application ./...
+        govulncheck ./...
 
   deploy:
     name: Deploy to AWS Lambda

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,19 @@
+run:
+    timeout: 2m
+linters:
+    disable-all: true
+    enable:
+#    - errcheck
+#    - gosimple
+#    - govet
+#    - ineffassign
+#    - staticcheck
+#    - unused
+    - bodyclose
+    - gocheckcompilerdirectives
+    - godox
+#    - gofmt
+#    - goimports
+#    - gosec
+#    - whitespace
+#    - usestdlibvars


### PR DESCRIPTION
[ITSE-921](https://itse.youtrack.cloud/issue/ITSE-921) use gosec and/or govulncheck in all Go apps

Rather than fix all of the lint issues immediately, I commented those checks in the configuration file. The next series of PRs will include solutions for the issues.