### PR TITLE
remove Webauthn client creation from authentication middleware

### DIFF
--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -60,14 +60,13 @@ func getTestWebauthnUsers(ms *MfaSuite, config baseTestConfig) []WebauthnUser {
 	apiKey2.Secret = "E286600E-3DBF-4C23-A0DA-9C55D448"
 
 	testUser0 := WebauthnUser{
-		ID:             apiKey0.Secret,
-		Name:           "Nancy_NoCredential",
-		DisplayName:    "Nancy NoCredential",
-		Store:          config.Storage,
-		WebAuthnClient: config.WebAuthnClient,
-		ApiKey:         apiKey0,
-		ApiKeyValue:    apiKey0.Key,
-		Credentials:    []webauthn.Credential{},
+		ID:          apiKey0.Secret,
+		Name:        "Nancy_NoCredential",
+		DisplayName: "Nancy NoCredential",
+		Store:       config.Storage,
+		ApiKey:      apiKey0,
+		ApiKeyValue: apiKey0.Key,
+		Credentials: []webauthn.Credential{},
 	}
 
 	testUser1 := testUser0

--- a/webauthn.go
+++ b/webauthn.go
@@ -55,6 +55,7 @@ func BeginRegistration(w http.ResponseWriter, r *http.Request) {
 	user, err := getUserFromContext(r)
 	if err != nil {
 		jsonResponse(w, err, http.StatusBadRequest)
+		return
 	}
 
 	// If user.id is empty, treat as new user/registration
@@ -94,6 +95,7 @@ func FinishRegistration(w http.ResponseWriter, r *http.Request) {
 	client, err := getWebauthnClient(r)
 	if err != nil {
 		jsonResponse(w, err, http.StatusInternalServerError)
+		return
 	}
 
 	keyHandleHash, err := user.FinishRegistration(r, client)
@@ -147,6 +149,7 @@ func FinishLogin(w http.ResponseWriter, r *http.Request) {
 	client, err := getWebauthnClient(r)
 	if err != nil {
 		jsonResponse(w, err, http.StatusInternalServerError)
+		return
 	}
 
 	credential, err := user.FinishLogin(r, client)


### PR DESCRIPTION
[IDP-1501](https://support.gtis.sil.org/issue/IDP-1501) refactor serverless-mfa-api-go

### Changed
- Removed the creation of the webauthn client from the authentication middleware and into each handler that actually requires a webauthn client. This will make API key and TOTP handlers (when added) simpler to implement.