### PR TITLE
add endpoints to create and activate API keys

### DIFF
--- a/apikey.go
+++ b/apikey.go
@@ -6,8 +6,12 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -28,9 +32,14 @@ type ApiKey struct {
 	Store        *Storage `dynamodbav:"-" json:"-"`
 }
 
-// Load refreshes a ApiKey object from the database record
+// Load refreshes an ApiKey from the database record
 func (k *ApiKey) Load() error {
 	return k.Store.Load(envConfig.ApiKeyTable, ApiKeyTablePK, k.Key, k)
+}
+
+// Save an ApiKey to the database
+func (k *ApiKey) Save() error {
+	return k.Store.Store(envConfig.ApiKeyTable, k)
 }
 
 // Hash generates a bcrypt hash from the Secret field and stores it in HashedSecret
@@ -145,13 +154,13 @@ func (k *ApiKey) DecryptLegacy(ciphertext []byte) ([]byte, error) {
 	iv := make([]byte, aes.BlockSize)
 	_, err = base64.StdEncoding.Decode(iv, parts[0])
 	if err != nil {
-		fmt.Printf("unable to decode iv: %s\n", err)
+		fmt.Printf("failed to decode iv: %s\n", err)
 		return nil, err
 	}
 
 	decodedCipher, err := base64.StdEncoding.DecodeString(string(parts[1]))
 	if err != nil {
-		fmt.Printf("unable to decode ciphertext: %s\n", err)
+		fmt.Printf("failed to decode ciphertext: %s\n", err)
 		return nil, err
 	}
 
@@ -164,4 +173,133 @@ func (k *ApiKey) DecryptLegacy(ciphertext []byte) ([]byte, error) {
 	stream.XORKeyStream(plaintext, decodedCipher)
 
 	return plaintext, nil
+}
+
+// Activate an ApiKey. Creates a random string for the key secret and updates the Secret, HashedSecret, and
+// ActivatedAt fields.
+func (k *ApiKey) Activate() error {
+	if k.ActivatedAt != 0 {
+		return errors.New("key already activated")
+	}
+
+	random := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, random); err != nil {
+		return fmt.Errorf("failed to create random secret: %w", err)
+	}
+
+	k.Secret = base64.StdEncoding.EncodeToString(random)
+	hashedSecret, err := bcrypt.GenerateFromPassword([]byte(k.Secret), 10)
+	if err != nil {
+		return fmt.Errorf("failed to hash secret: %w", err)
+	}
+
+	k.HashedSecret = string(hashedSecret)
+	k.ActivatedAt = int(time.Now().UTC().Unix() * 1000)
+	return nil
+}
+
+// ActivateApiKey is the handler for the POST /api-key/activate endpoint. It creates the key secret and updates the
+// database record.
+func ActivateApiKey(w http.ResponseWriter, r *http.Request) {
+	var requestBody struct {
+		ApiKeyValue string `json:"apiKeyValue"`
+		Email       string `json:"email"`
+	}
+
+	err := json.NewDecoder(r.Body).Decode(&requestBody)
+	if err != nil {
+		jsonResponse(w, fmt.Errorf("invalid request: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	if requestBody.ApiKeyValue == "" {
+		jsonResponse(w, fmt.Errorf("apiKeyValue is required"), http.StatusBadRequest)
+		return
+	}
+
+	if requestBody.Email == "" {
+		jsonResponse(w, fmt.Errorf("email is required"), http.StatusBadRequest)
+		return
+	}
+
+	storage, ok := r.Context().Value(StorageContextKey).(*Storage)
+	if !ok {
+		jsonResponse(w, fmt.Errorf("no storage client found in context"), http.StatusInternalServerError)
+		return
+	}
+
+	newKey := ApiKey{Key: requestBody.ApiKeyValue, Store: storage}
+	err = newKey.Load()
+	if err != nil {
+		jsonResponse(w, fmt.Errorf("key not found: %s", err), http.StatusNotFound)
+		return
+	}
+
+	err = newKey.Activate()
+	if err != nil {
+		jsonResponse(w, fmt.Errorf("failed to activate key: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	err = newKey.Save()
+	if err != nil {
+		jsonResponse(w, fmt.Errorf("failed to save key: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	jsonResponse(w, map[string]string{"apiSecret": newKey.Secret}, http.StatusOK)
+}
+
+// CreateApiKey is the handler for the POST /api-key endpoint. It creates a new API Key and saves it to the database.
+func CreateApiKey(w http.ResponseWriter, r *http.Request) {
+	var requestBody struct {
+		Email string `json:"email"`
+	}
+
+	err := json.NewDecoder(r.Body).Decode(&requestBody)
+	if err != nil {
+		jsonResponse(w, fmt.Errorf("invalid request: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	if requestBody.Email == "" {
+		jsonResponse(w, fmt.Errorf("email is required"), http.StatusBadRequest)
+		return
+	}
+
+	key, err := NewApiKey(requestBody.Email)
+	if err != nil {
+		jsonResponse(w, fmt.Errorf("failed to create a random key: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	storage, ok := r.Context().Value(StorageContextKey).(*Storage)
+	if !ok {
+		jsonResponse(w, fmt.Errorf("no storage client found in context"), http.StatusInternalServerError)
+		return
+	}
+	key.Store = storage
+
+	err = key.Save()
+	if err != nil {
+		jsonResponse(w, fmt.Errorf("failed to save key: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	jsonResponse(w, nil, http.StatusOK)
+}
+
+// NewApiKey creates a new key with a random value
+func NewApiKey(email string) (ApiKey, error) {
+	random := make([]byte, 20)
+	if _, err := io.ReadFull(rand.Reader, random); err != nil {
+		return ApiKey{}, err
+	}
+
+	key := ApiKey{
+		Key:       hex.EncodeToString(random),
+		Email:     email,
+		CreatedAt: int(time.Now().UTC().Unix() * 1000),
+	}
+	return key, nil
 }

--- a/apikey.go
+++ b/apikey.go
@@ -286,7 +286,7 @@ func CreateApiKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonResponse(w, nil, http.StatusOK)
+	jsonResponse(w, nil, http.StatusNoContent)
 }
 
 // NewApiKey creates a new key with a random value

--- a/apikey_test.go
+++ b/apikey_test.go
@@ -288,7 +288,7 @@ func (ms *MfaSuite) TestCreateApiKey() {
 			body: map[string]interface{}{
 				"email": "email@example.com",
 			},
-			wantStatus: http.StatusOK,
+			wantStatus: http.StatusNoContent,
 		},
 		{
 			name:       "missing email",

--- a/apikey_test.go
+++ b/apikey_test.go
@@ -2,7 +2,14 @@ package mfa
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
 	"testing"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestApiKey_IsCorrect(t *testing.T) {
@@ -128,4 +135,189 @@ func TestApiKey_EncryptDecrypt(t *testing.T) {
 			}
 		})
 	}
+}
+
+func (ms *MfaSuite) TestApiKeyActivate() {
+	notActive := ApiKey{
+		Key:       "0000000000000000000000000000000000000000",
+		Email:     "email@example.com",
+		CreatedAt: 1744788331000,
+	}
+	active := notActive
+	active.ActivatedAt = 1744788394000
+
+	tests := []struct {
+		name    string
+		key     ApiKey
+		wantErr bool
+	}{
+		{
+			name:    "not active",
+			key:     notActive,
+			wantErr: false,
+		},
+		{
+			name:    "already activated",
+			key:     active,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		ms.Run(tt.name, func() {
+			key := tt.key
+			err := key.Activate()
+			if tt.wantErr {
+				ms.Error(err)
+				return
+			}
+
+			ms.NoError(err)
+			ms.Regexp(regexp.MustCompile("[A-Za-z0-9+/]{43}="), key.Secret)
+			ms.NoError(bcrypt.CompareHashAndPassword([]byte(key.HashedSecret), []byte(key.Secret)))
+			ms.WithinDuration(time.Now(), time.Unix(int64(key.ActivatedAt/1000), 0), time.Minute)
+
+			// ensure no other fields were changed
+			ms.Equal(tt.key.Key, key.Key)
+			ms.Equal(tt.key.Email, key.Email)
+			ms.Equal(tt.key.CreatedAt, key.CreatedAt)
+		})
+	}
+}
+
+func (ms *MfaSuite) TestActivateApiKey() {
+	awsConfig := testAwsConfig()
+	testEnvConfig(awsConfig)
+	localStorage, err := NewStorage(awsConfig)
+	must(err)
+
+	key1 := ApiKey{Key: "key1"}
+	must(localStorage.Store(envConfig.ApiKeyTable, &key1))
+	key2 := ApiKey{Key: "key2", ActivatedAt: 1744799134000}
+	must(localStorage.Store(envConfig.ApiKeyTable, &key2))
+	key3 := ApiKey{Key: "key3"}
+	must(localStorage.Store(envConfig.ApiKeyTable, &key3))
+
+	tests := []struct {
+		name       string
+		body       any
+		wantStatus int
+		wantError  string
+	}{
+		{
+			name: "not previously activated",
+			body: map[string]interface{}{
+				"email":       "email@example.com",
+				"apiKeyValue": key1.Key,
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "already activated",
+			body: map[string]interface{}{
+				"email":       "email@example.com",
+				"apiKeyValue": key2.Key,
+			},
+			wantStatus: http.StatusBadRequest,
+			wantError:  "failed to activate key: key already activated",
+		},
+		{
+			name: "missing email",
+			body: map[string]interface{}{
+				"apiKeyValue": key3.Key,
+			},
+			wantStatus: http.StatusBadRequest,
+			wantError:  "email is required",
+		},
+		{
+			name: "missing apiKey",
+			body: map[string]interface{}{
+				"email": "email@example.com",
+			},
+			wantStatus: http.StatusBadRequest,
+			wantError:  "apiKeyValue is required",
+		},
+		{
+			name: "key not found",
+			body: map[string]interface{}{
+				"email":       "email@example.com",
+				"apiKeyValue": "not a key",
+			},
+			wantStatus: http.StatusNotFound,
+			wantError:  "key not found: item does not exist: not a key",
+		},
+	}
+	for _, tt := range tests {
+		ms.Run(tt.name, func() {
+			res := &lambdaResponseWriter{Headers: http.Header{}}
+			req := requestWithUser(tt.body, ApiKey{Store: localStorage})
+			ActivateApiKey(res, req)
+
+			if tt.wantStatus != http.StatusOK {
+				ms.Equal(tt.wantStatus, res.Status, fmt.Sprintf("response: %s", res.Body))
+				var se simpleError
+				ms.decodeBody(res.Body, &se)
+				ms.Equal(tt.wantError, se.Error)
+				return
+			}
+
+			ms.Equal(http.StatusOK, res.Status, fmt.Sprintf("response: %s", res.Body))
+
+			var response struct {
+				ApiSecret string `json:"apiSecret"`
+			}
+			ms.NoError(json.Unmarshal(res.Body, &response))
+			ms.Len(response.ApiSecret, 44)
+		})
+	}
+}
+
+func (ms *MfaSuite) TestCreateApiKey() {
+	awsConfig := testAwsConfig()
+	testEnvConfig(awsConfig)
+	localStorage, err := NewStorage(awsConfig)
+	must(err)
+
+	tests := []struct {
+		name       string
+		body       any
+		wantStatus int
+		wantError  string
+	}{
+		{
+			name: "success",
+			body: map[string]interface{}{
+				"email": "email@example.com",
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing email",
+			body:       map[string]interface{}{},
+			wantStatus: http.StatusBadRequest,
+			wantError:  "email is required",
+		},
+	}
+	for _, tt := range tests {
+		ms.Run(tt.name, func() {
+			res := &lambdaResponseWriter{Headers: http.Header{}}
+			req := requestWithUser(tt.body, ApiKey{Store: localStorage})
+			CreateApiKey(res, req)
+
+			if tt.wantStatus != http.StatusOK {
+				ms.Equal(tt.wantStatus, res.Status, fmt.Sprintf("response: %s", res.Body))
+				var se simpleError
+				ms.decodeBody(res.Body, &se)
+				ms.Equal(tt.wantError, se.Error)
+				return
+			}
+
+			ms.Equal(http.StatusOK, res.Status, fmt.Sprintf("response: %s", res.Body))
+		})
+	}
+}
+
+func (ms *MfaSuite) TestNewApiKey() {
+	got, err := NewApiKey("email@example.com")
+	ms.NoError(err)
+	ms.Regexp(regexp.MustCompile("[a-f0-9]{40}"), got)
 }

--- a/apikey_test.go
+++ b/apikey_test.go
@@ -303,7 +303,7 @@ func (ms *MfaSuite) TestCreateApiKey() {
 			req := requestWithUser(tt.body, ApiKey{Store: localStorage})
 			CreateApiKey(res, req)
 
-			if tt.wantStatus != http.StatusOK {
+			if tt.wantError != "" {
 				ms.Equal(tt.wantStatus, res.Status, fmt.Sprintf("response: %s", res.Body))
 				var se simpleError
 				ms.decodeBody(res.Body, &se)
@@ -311,7 +311,7 @@ func (ms *MfaSuite) TestCreateApiKey() {
 				return
 			}
 
-			ms.Equal(http.StatusOK, res.Status, fmt.Sprintf("response: %s", res.Body))
+			ms.Equal(tt.wantStatus, res.Status, fmt.Sprintf("response: %s", res.Body))
 		})
 	}
 }

--- a/auth.go
+++ b/auth.go
@@ -61,7 +61,7 @@ func AuthenticateRequest(r *http.Request) (User, error) {
 		return nil, fmt.Errorf("TOTP is not yet supported")
 
 	case "api-key":
-		return nil, fmt.Errorf("key management is not yet supported")
+		return nil, nil // no authentication required for api-key
 
 	default:
 		return nil, fmt.Errorf("invalid URL: %s", r.URL)

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -69,14 +69,23 @@ func addDeleteCredentialParamForMux(r *http.Request, key, value string) *http.Re
 
 func handler(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	r := httpRequestFromProxyRequest(ctx, req)
-	user, err := mfa.AuthenticateRequest(r)
+
+	storage, err := mfa.NewStorage(envConfig.AWSConfig)
 	if err != nil {
-		return clientError(http.StatusUnauthorized, fmt.Sprintf("unable to authenticate request: %s", err))
+		return clientError(http.StatusInternalServerError, fmt.Sprintf("error initializing storage: %s", err))
+	}
+	newCtx := context.WithValue(r.Context(), mfa.StorageContextKey, storage)
+
+	var user mfa.User
+	if !strings.HasPrefix(r.URL.Path, "/api-key") {
+		user, err = mfa.AuthenticateRequest(r)
+		if err != nil {
+			return clientError(http.StatusUnauthorized, fmt.Sprintf("unable to authenticate request: %s", err))
+		}
+		newCtx = context.WithValue(newCtx, mfa.UserContextKey, user)
 	}
 
-	// Add user into context for further use
-	nctx := context.WithValue(r.Context(), mfa.UserContextKey, user)
-	r = r.WithContext(nctx)
+	r = r.WithContext(newCtx)
 
 	// Use custom lambda http.ResponseWriter
 	w := newLambdaResponseWriter()
@@ -96,6 +105,10 @@ func handler(ctx context.Context, req events.APIGatewayProxyRequest) (events.API
 		route := strings.ToLower(fmt.Sprintf("%s %s", req.HTTPMethod, req.Path))
 
 		switch route {
+		case "post /api-key":
+			mfa.CreateApiKey(w, r)
+		case "post /api-key/activate":
+			mfa.ActivateApiKey(w, r)
 		case "post /webauthn/login":
 			mfa.BeginLogin(w, r)
 		case "put /webauthn/login":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -342,6 +342,104 @@ components:
       required:
       - error
 paths:
+  /api-key:
+    post:
+      operationId: createApiKey
+      summary: Create API Key
+      description: >
+        Create a new API key for access to other endpoints. All other endpoints use API keys to encrypt and decrypt
+        data. Consequently, no existing data can be read by an API key created after the creation of that data. Keys
+        are not usable until activated using the POST /api-key/activate endpoint
+      requestBody:
+        description: request body for CreateAPIKey request
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  description: email address of the requester
+                  required: true
+                  example: email@example.com
+      responses:
+        204:
+          description: New API key created
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimpleError"
+              examples:
+                invalid-input:
+                  value:
+                    error: "invalid request: invalid character ',' looking for beginning of value"
+                email-required:
+                  value:
+                    error: "email is required"
+  /api-key/activate:
+    post:
+      operationId: activateApiKey
+      summary: Activate API Key
+      description: >
+        Activate a new API key for access to other endpoints. Keys cannot be used before activation.
+      requestBody:
+        description: request body for ApiKeyActivate request
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                apiKeyValue:
+                  type: string
+                  description: email address of the requester
+                  required: true
+                  example: 0123456789012345678901234567890123456789
+                email:
+                  type: string
+                  description: email address of the requester
+                  required: true
+                  example: email@example.com
+      responses:
+        200:
+          description: New API key created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  apiSecret:
+                    type: string
+                    description: >
+                      a random string associated with the key, when paired with the key value can be used to
+                      authenticate against API endpoints
+                    required: true
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimpleError"
+              examples:
+                invalid-input:
+                  value:
+                    error: "invalid request: invalid character ',' looking for beginning of value"
+                email-required:
+                  value:
+                    error: "email is required"
+        404:
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimpleError"
+              examples:
+                not-found:
+                  value:
+                    error: "key not found: item does not exist: 0123456789012345678901234567890123456789"
   /webauthn/register:
     post:
       summary: Begin Registration

--- a/server/authentication_middleware.go
+++ b/server/authentication_middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	mfa "github.com/silinternational/serverless-mfa-api-go"
 )
@@ -13,6 +14,11 @@ import (
 // user from storage and attach to context.
 func authenticationMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api-key") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		user, err := mfa.AuthenticateRequest(r)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("unable to authenticate request: %s", err), http.StatusUnauthorized)

--- a/storage.go
+++ b/storage.go
@@ -11,6 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
+const StorageContextKey = "storage"
+
 // Storage provides wrapper methods for interacting with DynamoDB
 type Storage struct {
 	client *dynamodb.Client
@@ -70,6 +72,10 @@ func (s *Storage) Load(table, attrName, attrVal string, item interface{}) error 
 	result, err := s.client.GetItem(ctx, input)
 	if err != nil {
 		return err
+	}
+
+	if result.Item == nil {
+		return errors.New("item does not exist: " + attrVal)
 	}
 
 	return attributevalue.UnmarshalMap(result.Item, item)

--- a/suite_test.go
+++ b/suite_test.go
@@ -1,6 +1,8 @@
 package mfa
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,4 +27,11 @@ func Test_MfaSuite(t *testing.T) {
 	ms := &MfaSuite{}
 
 	suite.Run(t, ms)
+}
+
+func (ms *MfaSuite) decodeBody(body []byte, v any) {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	ms.NoError(decoder.Decode(v))
+	ms.False(decoder.More())
 }

--- a/terraform/lambda-role-policy.json
+++ b/terraform/lambda-role-policy.json
@@ -32,7 +32,8 @@
         "dynamodb:DescribeTable",
         "dynamodb:Query",
         "dynamodb:Scan",
-        "dynamodb:GetItem"
+        "dynamodb:GetItem",
+        "dynamodb:PutItem"
       ],
       "Resource": [
         "arn:aws:dynamodb:*:${aws_account}:table/${api_key_table}"

--- a/webauthn_test.go
+++ b/webauthn_test.go
@@ -479,7 +479,7 @@ func (ms *MfaSuite) Test_BeginLogin() {
 	ctxWithUserCredentials := context.WithValue(reqWithCredentials.Context(), UserContextKey, userWithCreds)
 	reqWithCredentials = *reqWithCredentials.WithContext(ctxWithUserCredentials)
 
-	localStorage.Store(envConfig.WebauthnTable, ctxWithUserCredentials)
+	localStorage.Store(envConfig.WebauthnTable, userWithCreds)
 
 	tests := []struct {
 		name             string

--- a/webauthnuser.go
+++ b/webauthnuser.go
@@ -103,11 +103,8 @@ func (u *WebauthnUser) unsetSessionData() error {
 // saveSessionData encrypts the user's session data and updates the database record.
 // CAUTION: user data is refreshed from the database by this function. Any unsaved data will be lost.
 func (u *WebauthnUser) saveSessionData(sessionData webauthn.SessionData) error {
-	// load to be sure working with latest data
-	err := u.Load()
-	if err != nil {
-		return err
-	}
+	// load to be sure working with latest data, but we may not have created the record yet (BeginRegistration)
+	_ = u.Load()
 
 	js, err := json.Marshal(sessionData)
 	if err != nil {


### PR DESCRIPTION
[IDP-1514](https://support.gtis.sil.org/issue/IDP-1514) add api-key endpoints to serverless-mfa-api-go

### Added
- Added two new endpoints: `POST /api-key` and `POST /api-key/activate`
- Added storage middleware to save an initialized storage client in the request context. (Side note: dependency injection is a better solution, but I decided to continue with the existing paradigm for now.)

### Changed
- Change the Storage Load function to fail when no record is found. The only place this broke existing code was in BeginRegistration, but was easily fixed.
- Renamed testutils.go to utils_test.go to hide test code from the app build.