### PR TITLE
Move U2F decryption into Load

### DIFF
--- a/apikey.go
+++ b/apikey.go
@@ -143,6 +143,10 @@ func (k *ApiKey) EncryptLegacy(plaintext []byte) ([]byte, error) {
 // DecryptLegacy uses the Secret to AES decrypt an arbitrary data block. This is intended only for legacy data such
 // as U2F keys.
 func (k *ApiKey) DecryptLegacy(ciphertext string) (string, error) {
+	if ciphertext == "" {
+		return "", nil
+	}
+
 	block, err := newCipherBlock(k.Secret)
 	if err != nil {
 		return "", err

--- a/apikey.go
+++ b/apikey.go
@@ -1,7 +1,6 @@
 package mfa
 
 import (
-	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -12,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -150,19 +150,18 @@ func (k *ApiKey) DecryptLegacy(ciphertext string) (string, error) {
 
 	// data was encrypted, then base64 encoded, then joined with a :, need to split
 	// on :, then decode first part as iv and second as encrypted content
-	parts := bytes.Split([]byte(ciphertext), []byte(":"))
+	parts := strings.Split(ciphertext, ":")
 	if len(parts) != 2 {
 		return "", fmt.Errorf("ciphertext does not look like legacy data")
 	}
 
-	iv := make([]byte, aes.BlockSize)
-	_, err = base64.StdEncoding.Decode(iv, parts[0])
+	iv, err := base64.StdEncoding.DecodeString(parts[0])
 	if err != nil {
 		fmt.Printf("failed to decode iv: %s\n", err)
 		return "", err
 	}
 
-	decodedCipher, err := base64.StdEncoding.DecodeString(string(parts[1]))
+	decodedCipher, err := base64.StdEncoding.DecodeString(parts[1])
 	if err != nil {
 		fmt.Printf("failed to decode ciphertext: %s\n", err)
 		return "", err

--- a/apikey_test.go
+++ b/apikey_test.go
@@ -149,9 +149,9 @@ func (ms *MfaSuite) TestApiKeyEncryptDecryptLegacy() {
 
 	encrypted, err := key.EncryptLegacy(plaintext)
 	ms.NoError(err)
-	decrypted, err := key.DecryptLegacy(encrypted)
+	decrypted, err := key.DecryptLegacy(string(encrypted))
 	ms.NoError(err)
-	ms.Equal(plaintext, decrypted)
+	ms.Equal(plaintext, []byte(decrypted))
 }
 
 func (ms *MfaSuite) TestApiKeyActivate() {

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -67,8 +67,6 @@ func getTestWebauthnUsers(ms *MfaSuite, config baseTestConfig) []WebauthnUser {
 		WebAuthnClient: config.WebAuthnClient,
 		ApiKey:         apiKey0,
 		ApiKeyValue:    apiKey0.Key,
-		// Credentials:    []webauthn.Credential{},
-		// SessionData:    webauthn.SessionData{},
 	}
 
 	testUser1 := testUser0

--- a/webauthnuser.go
+++ b/webauthnuser.go
@@ -249,27 +249,27 @@ func (u *WebauthnUser) Load() error {
 	}
 
 	if u.EncryptedAppId != "" {
-		appid, err := u.ApiKey.DecryptLegacy([]byte(u.EncryptedAppId))
+		appid, err := u.ApiKey.DecryptLegacy(u.EncryptedAppId)
 		if err != nil {
 			return fmt.Errorf("failed to decrypt app id: %w", err)
 		}
-		u.AppId = string(appid)
+		u.AppId = appid
 	}
 
 	if u.EncryptedPublicKey != "" {
-		publicKey, err := u.ApiKey.DecryptLegacy([]byte(u.EncryptedPublicKey))
+		publicKey, err := u.ApiKey.DecryptLegacy(u.EncryptedPublicKey)
 		if err != nil {
 			return fmt.Errorf("failed to decrypt public key: %w", err)
 		}
-		u.PublicKey = string(publicKey)
+		u.PublicKey = publicKey
 	}
 
 	if u.EncryptedKeyHandle != "" {
-		keyHandle, err := u.ApiKey.DecryptLegacy([]byte(u.EncryptedKeyHandle))
+		keyHandle, err := u.ApiKey.DecryptLegacy(u.EncryptedKeyHandle)
 		if err != nil {
 			return fmt.Errorf("failed to decrypt key handle: %w", err)
 		}
-		u.KeyHandle = string(keyHandle)
+		u.KeyHandle = keyHandle
 	}
 
 	return nil

--- a/webauthnuser.go
+++ b/webauthnuser.go
@@ -248,6 +248,30 @@ func (u *WebauthnUser) Load() error {
 		u.Credentials = creds
 	}
 
+	if u.EncryptedAppId != "" {
+		appid, err := u.ApiKey.DecryptLegacy([]byte(u.EncryptedAppId))
+		if err != nil {
+			return fmt.Errorf("failed to decrypt app id: %w", err)
+		}
+		u.AppId = string(appid)
+	}
+
+	if u.EncryptedPublicKey != "" {
+		publicKey, err := u.ApiKey.DecryptLegacy([]byte(u.EncryptedPublicKey))
+		if err != nil {
+			return fmt.Errorf("failed to decrypt public key: %w", err)
+		}
+		u.PublicKey = string(publicKey)
+	}
+
+	if u.EncryptedKeyHandle != "" {
+		keyHandle, err := u.ApiKey.DecryptLegacy([]byte(u.EncryptedKeyHandle))
+		if err != nil {
+			return fmt.Errorf("failed to decrypt key handle: %w", err)
+		}
+		u.KeyHandle = string(keyHandle)
+	}
+
 	return nil
 }
 
@@ -322,12 +346,8 @@ func (u *WebauthnUser) FinishRegistration(r *http.Request) (string, error) {
 // CredentialAssertion data to pass back to the client. User session data is saved in the database.
 func (u *WebauthnUser) BeginLogin() (*protocol.CredentialAssertion, error) {
 	extensions := protocol.AuthenticationExtensions{}
-	if u.EncryptedAppId != "" {
-		appid, err := u.ApiKey.DecryptLegacy([]byte(u.EncryptedAppId))
-		if err != nil {
-			return nil, fmt.Errorf("unable to decrypt legacy app id: %w", err)
-		}
-		extensions["appid"] = string(appid)
+	if u.AppId != "" {
+		extensions["appid"] = u.AppId
 	}
 
 	options, sessionData, err := u.WebAuthnClient.BeginLogin(u, webauthn.WithAssertionExtensions(extensions), webauthn.WithUserVerification(protocol.VerificationDiscouraged))
@@ -366,13 +386,8 @@ func (u *WebauthnUser) FinishLogin(r *http.Request) (*webauthn.Credential, error
 
 	// If user has registered U2F creds, check if RPIDHash is actually hash of AppId
 	// if so, replace authenticator data RPIDHash with a hash of the RPID for validation
-	if u.EncryptedAppId != "" {
-		appid, err := u.ApiKey.DecryptLegacy([]byte(u.EncryptedAppId))
-		if err != nil {
-			return nil, fmt.Errorf("unable to decrypt legacy app id: %w", err)
-		}
-
-		appIdHash := sha256.Sum256(appid)
+	if u.AppId != "" {
+		appIdHash := sha256.Sum256([]byte(u.AppId))
 		rpIdHash := sha256.Sum256([]byte(u.WebAuthnClient.Config.RPID))
 
 		if fmt.Sprintf("%x", parsedResponse.Response.AuthenticatorData.RPIDHash) == fmt.Sprintf("%x", appIdHash) {
@@ -416,27 +431,13 @@ func (u *WebauthnUser) WebAuthnCredentials() []webauthn.Credential {
 		return u.Credentials
 	}
 
-	credId, err := u.ApiKey.DecryptLegacy([]byte(u.EncryptedKeyHandle))
-	if err != nil {
-		log.Printf("unable to decrypt credential id: %s", err)
-		return nil
-	}
-
-	decodedCredId, err := base64.RawURLEncoding.DecodeString(string(credId))
+	decodedCredId, err := base64.RawURLEncoding.DecodeString(u.KeyHandle)
 	if err != nil {
 		log.Println("error decoding credential id:", err)
 		return nil
 	}
 
-	pubKey, err := u.ApiKey.DecryptLegacy([]byte(u.EncryptedPublicKey))
-	if err != nil {
-		log.Printf("unable to decrypt pubic key: %s", err)
-		return nil
-	}
-	// Same as credId
-	// pubKey = bytes.Trim(pubKey, "\x00")
-
-	decodedPubKey, err := base64.RawURLEncoding.DecodeString(string(pubKey))
+	decodedPubKey, err := base64.RawURLEncoding.DecodeString(u.PublicKey)
 	if err != nil {
 		log.Println("error decoding public key:", err)
 		return nil

--- a/webauthnuser.go
+++ b/webauthnuser.go
@@ -248,29 +248,23 @@ func (u *WebauthnUser) Load() error {
 		u.Credentials = creds
 	}
 
-	if u.EncryptedAppId != "" {
-		appid, err := u.ApiKey.DecryptLegacy(u.EncryptedAppId)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt app id: %w", err)
-		}
-		u.AppId = appid
+	appid, err := u.ApiKey.DecryptLegacy(u.EncryptedAppId)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt app id: %w", err)
 	}
+	u.AppId = appid
 
-	if u.EncryptedPublicKey != "" {
-		publicKey, err := u.ApiKey.DecryptLegacy(u.EncryptedPublicKey)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt public key: %w", err)
-		}
-		u.PublicKey = publicKey
+	publicKey, err := u.ApiKey.DecryptLegacy(u.EncryptedPublicKey)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt public key: %w", err)
 	}
+	u.PublicKey = publicKey
 
-	if u.EncryptedKeyHandle != "" {
-		keyHandle, err := u.ApiKey.DecryptLegacy(u.EncryptedKeyHandle)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt key handle: %w", err)
-		}
-		u.KeyHandle = keyHandle
+	keyHandle, err := u.ApiKey.DecryptLegacy(u.EncryptedKeyHandle)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt key handle: %w", err)
 	}
+	u.KeyHandle = keyHandle
 
 	return nil
 }

--- a/webauthnuser_test.go
+++ b/webauthnuser_test.go
@@ -37,13 +37,8 @@ func (ms *MfaSuite) Test_User_DeleteCredential() {
 			wantStatus:      http.StatusNotFound,
 			wantErrContains: "no webauthn credentials available",
 			verifyFn: func(results *dynamodb.ScanOutput) {
-				found := false
-				for i := range results.Items {
-					if results.Items[i]["encryptedAppId"].(*types.AttributeValueMemberS).Value == "someEncryptedAppId" {
-						found = true
-					}
-				}
-				ms.True(found)
+				// all three test users should remain
+				ms.Len(results.Items, 3)
 			},
 		},
 		{


### PR DESCRIPTION
### Changed
- Decrypt the U2F data at load time, which is the same way the WebAuthn data is handled.
- Changed the `DecryptLegacy` function to use `string` rather than `[]byte` since that's the type of the data fields it operates on and the encrypted data is base64-encoded.