### PR TITLE
use string argument and return value

### DIFF
--- a/apikey.go
+++ b/apikey.go
@@ -120,24 +120,24 @@ func (k *ApiKey) DecryptData(ciphertext []byte) ([]byte, error) {
 
 // EncryptLegacy uses the Secret to AES encrypt an arbitrary data block. This is intended only for legacy data such
 // as U2F keys. The returned data is the Base64-encoded IV and the Base64-encoded cipher text separated by a colon.
-func (k *ApiKey) EncryptLegacy(plaintext []byte) ([]byte, error) {
+func (k *ApiKey) EncryptLegacy(plaintext string) (string, error) {
 	block, err := newCipherBlock(k.Secret)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	iv := make([]byte, aes.BlockSize)
 	if _, err = io.ReadFull(rand.Reader, iv); err != nil {
-		return nil, fmt.Errorf("failed to create random data for initialization vector: %w", err)
+		return "", fmt.Errorf("failed to create random data for initialization vector: %w", err)
 	}
 
 	ciphertext := make([]byte, len(plaintext))
 	stream := cipher.NewCTR(block, iv)
-	stream.XORKeyStream(ciphertext, plaintext)
+	stream.XORKeyStream(ciphertext, []byte(plaintext))
 
 	ivBase64 := base64.StdEncoding.EncodeToString(iv)
 	cipherBase64 := base64.StdEncoding.EncodeToString(ciphertext)
-	return []byte(ivBase64 + ":" + cipherBase64), nil
+	return ivBase64 + ":" + cipherBase64, nil
 }
 
 // DecryptLegacy uses the Secret to AES decrypt an arbitrary data block. This is intended only for legacy data such

--- a/apikey_test.go
+++ b/apikey_test.go
@@ -144,14 +144,14 @@ func TestApiKey_EncryptDecrypt(t *testing.T) {
 }
 
 func (ms *MfaSuite) TestApiKeyEncryptDecryptLegacy() {
-	plaintext := []byte("this is a plaintext string to be encrypted")
+	plaintext := "this is a plaintext string to be encrypted"
 	key := &ApiKey{Secret: "ED86600E-3DBF-4C23-A0DA-9C55D448"}
 
 	encrypted, err := key.EncryptLegacy(plaintext)
 	ms.NoError(err)
-	decrypted, err := key.DecryptLegacy(string(encrypted))
+	decrypted, err := key.DecryptLegacy(encrypted)
 	ms.NoError(err)
-	ms.Equal(plaintext, []byte(decrypted))
+	ms.Equal(plaintext, decrypted)
 }
 
 func (ms *MfaSuite) TestApiKeyActivate() {

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -111,7 +111,7 @@ func getTestWebauthnUsers(ms *MfaSuite, config baseTestConfig) []WebauthnUser {
 }
 
 func mustEncryptLegacy(key ApiKey, plaintext string) string {
-	ciphertext, err := key.EncryptLegacy([]byte(plaintext))
+	ciphertext, err := key.EncryptLegacy(plaintext)
 	must(err)
-	return string(ciphertext)
+	return ciphertext
 }


### PR DESCRIPTION
### Changed
- Use `string` for the argument and return from EncryptLegacy