### PR TITLE
re-encrypt WebAuthn records

### DIFF
--- a/apikey_test.go
+++ b/apikey_test.go
@@ -382,6 +382,102 @@ func (ms *MfaSuite) TestNewCipherBlock() {
 	}
 }
 
+func (ms *MfaSuite) TestReEncryptWebAuthnUsers() {
+	awsConfig := testAwsConfig()
+	testEnvConfig(awsConfig)
+	storage, err := NewStorage(awsConfig)
+	must(err)
+
+	baseConfigs := getDBConfig(ms)
+	users := getTestWebauthnUsers(ms, baseConfigs)
+
+	newKey, err := NewApiKey("email@example.com")
+	must(err)
+	must(newKey.Activate())
+	must(ms.app.GetDB().Store(ms.app.GetConfig().ApiKeyTable, newKey))
+
+	err = newKey.ReEncryptWebAuthnUsers(storage, users[0].ApiKey)
+	ms.NoError(err)
+
+	// verify only users[0] is affected because each test user belongs to a different key
+	for i, user := range users {
+		dbUser := user
+		must(dbUser.Load())
+		if i == 0 {
+			ms.NotEqual(user, dbUser)
+		} else {
+			ms.Equal(user, dbUser)
+		}
+	}
+}
+
+func (ms *MfaSuite) TestReEncryptWebAuthnUser() {
+	awsConfig := testAwsConfig()
+	testEnvConfig(awsConfig)
+	storage, err := NewStorage(awsConfig)
+	must(err)
+
+	baseConfigs := getDBConfig(ms)
+	users := getTestWebauthnUsers(ms, baseConfigs)
+
+	tests := []struct {
+		name string
+		user WebauthnUser
+	}{
+		{
+			name: "rotate U2F user",
+			user: users[0],
+		},
+		{
+			name: "rotate WebAuthn user",
+			user: users[1],
+		},
+	}
+	for _, tt := range tests {
+		ms.Run(tt.name, func() {
+			newKey, err := NewApiKey("email@example.com")
+			must(err)
+			must(newKey.Activate())
+			must(ms.app.GetDB().Store(ms.app.GetConfig().ApiKeyTable, newKey))
+			ms.NotEqual(newKey.Secret, tt.user.ApiKey.Secret)
+
+			err = newKey.ReEncryptWebAuthnUser(storage, tt.user)
+			ms.NoError(err)
+
+			dbUser := WebauthnUser{ID: tt.user.ID, ApiKey: newKey, Store: storage}
+			must(dbUser.Load())
+
+			// check U2F data
+			ms.DifferentOrEmptyString(tt.user.EncryptedAppId, dbUser.EncryptedAppId)
+			ms.DifferentOrEmptyString(tt.user.EncryptedKeyHandle, dbUser.EncryptedKeyHandle)
+			ms.DifferentOrEmptyString(tt.user.EncryptedPublicKey, dbUser.EncryptedPublicKey)
+			ms.Equal(tt.user.AppId, dbUser.AppId)
+			ms.Equal(tt.user.KeyHandle, dbUser.KeyHandle)
+			ms.Equal(tt.user.PublicKey, dbUser.PublicKey)
+
+			// check WebAuthn data
+			ms.DifferentOrNilByteSlice(tt.user.EncryptedCredentials, dbUser.EncryptedCredentials)
+			ms.DifferentOrNilByteSlice(tt.user.EncryptedSessionData, dbUser.EncryptedSessionData)
+			ms.Equal(tt.user.Credentials, dbUser.Credentials)
+			ms.Equal(tt.user.SessionData, dbUser.SessionData)
+		})
+	}
+}
+
+func (ms *MfaSuite) DifferentOrEmptyString(a, b string) {
+	if a == "" && b == "" {
+		return
+	}
+	ms.NotEqual(a, b)
+}
+
+func (ms *MfaSuite) DifferentOrNilByteSlice(a, b []byte) {
+	if a == nil && b == nil {
+		return
+	}
+	ms.NotEqual(a, b)
+}
+
 func (ms *MfaSuite) TestApiKeyReEncrypt() {
 	oldKey := ApiKey{}
 	must(oldKey.Activate())

--- a/webauthnuser.go
+++ b/webauthnuser.go
@@ -194,17 +194,20 @@ func (u *WebauthnUser) DeleteCredential(credIDHash string) (int, error) {
 
 // encryptAndStoreCredentials encrypts the user's credential list and updates the database record
 func (u *WebauthnUser) encryptAndStoreCredentials() error {
-	js, err := json.Marshal(u.Credentials)
-	if err != nil {
-		return err
-	}
+	if len(u.Credentials) == 0 {
+		u.EncryptedCredentials = nil
+	} else {
+		js, err := json.Marshal(u.Credentials)
+		if err != nil {
+			return err
+		}
 
-	enc, err := u.ApiKey.EncryptData(js)
-	if err != nil {
-		return err
+		enc, err := u.ApiKey.EncryptData(js)
+		if err != nil {
+			return err
+		}
+		u.EncryptedCredentials = enc
 	}
-	u.EncryptedCredentials = enc
-
 	return u.Store.Store(envConfig.WebauthnTable, u)
 }
 

--- a/webauthnuser_test.go
+++ b/webauthnuser_test.go
@@ -111,7 +111,7 @@ func (ms *MfaSuite) Test_User_DeleteCredential() {
 				ApiKey: tt.user.ApiKey,
 				Store:  baseConfigs.Storage,
 			}
-			gotUser.Load()
+			must(gotUser.Load())
 
 			ms.Len(gotUser.Credentials, len(tt.wantCredIDs), "incorrect remaining credential ids")
 


### PR DESCRIPTION
[IDP-1089](https://support.gtis.sil.org/issue/IDP-1089) serverless-mfa-api #6: Enable changing the API Secret in case it is compromised

### Added
- Added functions to re-encrypt WebAuthn tokens for API key rotation

### Fixed
- Fixed a problem in `encryptAndStoreCredentials` when used on a WebAuthnUser that has no credentials. It would fail because the data length is too small to encrypt. This is only applicable when re-encrypting legacy U2F tokens.