### PR TITLE
new endpoint to rotate an API key by re-encrypting all related data

### DIFF
--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -50,14 +50,17 @@ func getTestWebauthnUsers(ms *MfaSuite, config baseTestConfig) []WebauthnUser {
 		Store:       config.Storage,
 		ActivatedAt: 1,
 	}
+	must(apiKey0.Hash())
 
 	apiKey1 := apiKey0
 	apiKey1.Key = "1134567890123456"
 	apiKey1.Secret = "E186600E-3DBF-4C23-A0DA-9C55D448"
+	must(apiKey1.Hash())
 
 	apiKey2 := apiKey0
 	apiKey2.Key = "1234567890123456"
 	apiKey2.Secret = "E286600E-3DBF-4C23-A0DA-9C55D448"
+	must(apiKey2.Hash())
 
 	testUser0 := WebauthnUser{
 		ID:             apiKey0.Secret,

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -104,6 +104,8 @@ func handler(ctx context.Context, req events.APIGatewayProxyRequest) (events.API
 			app.CreateApiKey(w, r)
 		case "post /api-key/activate":
 			app.ActivateApiKey(w, r)
+		case "post /api-key/rotate":
+			app.RotateApiKey(w, r)
 		case "post /webauthn/login":
 			app.BeginLogin(w, r)
 		case "put /webauthn/login":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -440,6 +440,90 @@ paths:
                 not-found:
                   value:
                     error: "key not found: item does not exist: 0123456789012345678901234567890123456789"
+  /api-key/rotate:
+    post:
+      operationId: rotateApiKey
+      summary: Rotate API Key
+      description: >
+        All data in webauthn and totp tables that is encrypted by the old key will be re-encrypted using the new key.
+        If the process does not run to completion, this endpoint can be called any number of times to continue the
+        process. A status of 200 does not indicate that all keys were encrypted using the new key. Check the response
+        data to determine if the rotation process is complete.
+      requestBody:
+        description: request body for ApiKeyRotate request
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                oldKeyId:
+                  type: string
+                  description: old API Key ID
+                  required: true
+                  example: 0123456789012345678901234567890123456789
+                oldKeySecret:
+                  type: string
+                  description: old API Key secret
+                  required: true
+                  example: 0123456789012345678901234567890123456789012=
+                newKeyId:
+                  type: string
+                  description: new API Key ID
+                  required: true
+                  example: 0123456789012345678901234567890123456789
+                newKeySecret:
+                  type: string
+                  description: new API Key secret
+                  required: true
+                  example: 0123456789012345678901234567890123456789012=
+      responses:
+        200:
+          description: New API secret created and data re-encrypted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  totpComplete:
+                    type: integer
+                    description: the number of TOTP codes that were encrypted with the new key
+                    required: true
+                  totpIncomplete:
+                    type: integer
+                    description: the number of TOTP codes that have not yet been encrypted with the new key
+                    required: true
+                  webauthnComplete:
+                    type: integer
+                    description: the number of Webauthn passkeys that were encrypted with the new key
+                    required: true
+                  webauthnIncomplete:
+                    type: integer
+                    description: the number of Webauthn passkeys that have not yet been encrypted with the new key
+                    required: true
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimpleError"
+              examples:
+                invalid-input:
+                  value:
+                    error: "invalid request: invalid character ',' looking for beginning of value"
+                api-key-required:
+                  value:
+                    error: "apiKeyValue is required"
+        404:
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimpleError"
+              examples:
+                not-found:
+                  value:
+                    error: "key not found: item does not exist: 0123456789012345678901234567890123456789"
   /webauthn/register:
     post:
       summary: Begin Registration

--- a/server/main.go
+++ b/server/main.go
@@ -51,6 +51,12 @@ func getRoutes(app *mfa.App) []route {
 			HandlerFunc: app.ActivateApiKey,
 		},
 		{
+			Name:        "RotateApiKey",
+			Method:      "POST",
+			Pattern:     "/api-key/rotate",
+			HandlerFunc: app.RotateApiKey,
+		},
+		{
 			Name:        "CreateApiKey",
 			Method:      "POST",
 			Pattern:     "/api-key",

--- a/totp.go
+++ b/totp.go
@@ -1,0 +1,7 @@
+package mfa
+
+type TOTP struct {
+	UUID             string `dynamodbav:"uuid" json:"uuid"`
+	ApiKey           string `dynamodbav:"apiKey" json:"apiKey"`
+	EncryptedTotpKey string `dynamodbav:"encryptedTotpKey" json:"encryptedTotpKey"`
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -39,6 +40,7 @@ func testAwsConfig() aws.Config {
 func testEnvConfig(awsConfig aws.Config) EnvConfig {
 	envCfg := EnvConfig{
 		ApiKeyTable:      "ApiKey",
+		TotpTable:        "Totp",
 		WebauthnTable:    "WebAuthn",
 		AwsEndpoint:      os.Getenv("AWS_ENDPOINT"),
 		AwsDefaultRegion: os.Getenv("AWS_DEFAULT_REGION"),
@@ -61,7 +63,7 @@ func initDb(storage *Storage) error {
 	ctx := context.Background()
 
 	// attempt to delete tables in case already exists
-	tables := map[string]string{"WebAuthn": "uuid", "ApiKey": "value"}
+	tables := map[string]string{"Totp": "uuid", "WebAuthn": "uuid", "ApiKey": "value"}
 	for name := range tables {
 		deleteTable := &dynamodb.DeleteTableInput{
 			TableName: aws.String(name),
@@ -92,7 +94,7 @@ func initDb(storage *Storage) error {
 		}
 		_, err = storage.client.CreateTable(ctx, createTable)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to create table %s: %w", table, err)
 		}
 	}
 


### PR DESCRIPTION
[IDP-1089](https://support.gtis.sil.org/issue/IDP-1089) serverless-mfa-api #6: Enable changing the API Secret in case it is compromised