### PR TITLE
update to Go 1.26.4

### DIFF
--- a/cdk/go.mod
+++ b/cdk/go.mod
@@ -1,6 +1,6 @@
 module cdk
 
-go 1.26
+go 1.26.4
 
 require (
 	github.com/aws/aws-cdk-go/awscdk/v2 v2.185.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sil-org/serverless-mfa-api-go
 
-go 1.26
+go 1.26.4
 
 require (
 	github.com/aws/aws-lambda-go v1.49.0


### PR DESCRIPTION
### Security

- Update Go to 1.26.4 to address vulnerabilities GO-2026-5037 and GO-2026-5039.
