### PR TITLE
copy single-use Terraform modules into this repo

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -63,3 +63,22 @@ provider "registry.terraform.io/hashicorp/template" {
     "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/tfe" {
+  version = "0.78.0"
+  hashes = [
+    "h1:G1hH2nmuFT7rXMxBhz+s32Xv0BSUNblRqr30FXQIpQc=",
+    "zh:07a92efc738951a8c942db2be6dcf82e79345c6e088e70d0c0bedcdeabc87e85",
+    "zh:27483e407af30aad50bfcedfefc044fc37c5a31ac4c36c161cef6ff962b76b75",
+    "zh:425af1b3deb27c59057faa7c46893c9f486df14d893df71e554f313c5037592e",
+    "zh:4fa0289fd7a52e6e3d2c6e016e0f698a025ac6b88d079726474262ea888fe3bb",
+    "zh:525e45c1d079cdae1dfd8b8cc5635dfb641e82b70a44323f40b320defaa1997a",
+    "zh:541d4532c875b2ee7ecb98da9a1461e76788893b623b0adf7c634d9fff7770e3",
+    "zh:5af586f1652526aba097d3f19d048a9d0a02b559628de7f4143c448d8a9f5b7b",
+    "zh:99139dfa499c065655be4ccff60f21c562bafdde61d9b64ca83e30ad03fb7712",
+    "zh:bba9c198a3d36f079ee12eb82600d3731bd356a737f633f45828b1ec7cff4990",
+    "zh:f32c77c89257995579e105fefd3bb2940c5d4e4c0eef1a1475a3d94974015bb9",
+    "zh:f5cd462ec456e4707cbd5ebf809b3440cf0f3f615e7ab90f17fabadb2cfca33c",
+    "zh:faef65b220a716f46e41d3591298b21a209a11c20bd51560da8938ef2bb282e0",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,8 +57,7 @@ resource "aws_iam_role_policy" "cd" {
 
 // Set up custom domain name for easier fail-over.
 module "dns_for_failover" {
-  source  = "sil-org/serverless-api-dns-for-failover/aws"
-  version = "~> 0.6.0"
+  source = "./modules/serverless-api-dns-for-failover"
 
   api_name             = local.api_name
   cloudflare_zone_name = var.cloudflare_domain

--- a/terraform/modules/api-gateway-custom-domain/README.md
+++ b/terraform/modules/api-gateway-custom-domain/README.md
@@ -1,0 +1,3 @@
+# Terraform module for API Gateway custom domain
+
+This module sets up a custom domain name for an API Gateway Regional REST API.

--- a/terraform/modules/api-gateway-custom-domain/main.tf
+++ b/terraform/modules/api-gateway-custom-domain/main.tf
@@ -1,0 +1,22 @@
+
+# NOTE: For REST APIs, use `aws_api_gateway_*` resources, not
+# `aws_apigatewayv2_*` resources.
+data "aws_api_gateway_rest_api" "this" {
+  name = var.api_name
+}
+
+resource "aws_api_gateway_domain_name" "this" {
+  domain_name              = var.domain_name
+  regional_certificate_arn = var.certificate_arn
+  security_policy          = "TLS_1_2"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}
+
+resource "aws_api_gateway_base_path_mapping" "this" {
+  api_id      = data.aws_api_gateway_rest_api.this.id
+  domain_name = var.domain_name
+  stage_name  = var.stage
+}

--- a/terraform/modules/api-gateway-custom-domain/outputs.tf
+++ b/terraform/modules/api-gateway-custom-domain/outputs.tf
@@ -1,0 +1,4 @@
+
+output "regional_domain_name" {
+  value = aws_api_gateway_domain_name.this.regional_domain_name
+}

--- a/terraform/modules/api-gateway-custom-domain/variables.tf
+++ b/terraform/modules/api-gateway-custom-domain/variables.tf
@@ -1,0 +1,20 @@
+
+variable "api_name" {
+  description = "The API Gateway API name, for associating with this custom domain"
+  type        = string
+}
+
+variable "certificate_arn" {
+  description = "The ARN for the Amazon certificate to use for this domain name"
+  type        = string
+}
+
+variable "domain_name" {
+  description = "The exact domain name for the API Gateway custom domain"
+  type        = string
+}
+
+variable "stage" {
+  description = "The stage of the API to map this domain name to (e.g. 'dev' or 'prod')"
+  type        = string
+}

--- a/terraform/modules/api-gateway-custom-domain/versions.tf
+++ b/terraform/modules/api-gateway-custom-domain/versions.tf
@@ -1,0 +1,11 @@
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4"
+    }
+  }
+}

--- a/terraform/modules/api-gateway-domains-and-certs/main.tf
+++ b/terraform/modules/api-gateway-domains-and-certs/main.tf
@@ -1,0 +1,26 @@
+
+module "primary_region" {
+  source = "../certificate-and-domain"
+
+  api_name              = var.api_name
+  api_stage             = var.api_stage
+  certificate_subdomain = var.certificate_subdomain
+  cloudflare_zone_name  = var.cloudflare_zone_name
+
+  providers = { aws = aws }
+}
+
+module "secondary_region" {
+  source     = "../certificate-and-domain"
+  depends_on = [module.primary_region]
+
+  api_name              = var.api_name
+  api_stage             = var.api_stage
+  certificate_subdomain = var.certificate_subdomain
+  cloudflare_zone_name  = var.cloudflare_zone_name
+
+  # Don't create another DNS record, since it's the same for both regions.
+  create_dns_validation = false
+
+  providers = { aws = aws.secondary }
+}

--- a/terraform/modules/api-gateway-domains-and-certs/outputs.tf
+++ b/terraform/modules/api-gateway-domains-and-certs/outputs.tf
@@ -1,0 +1,8 @@
+
+output "primary_api_gateway_domain" {
+  value = module.primary_region.regional_domain_name
+}
+
+output "secondary_api_gateway_domain" {
+  value = module.secondary_region.regional_domain_name
+}

--- a/terraform/modules/api-gateway-domains-and-certs/variables.tf
+++ b/terraform/modules/api-gateway-domains-and-certs/variables.tf
@@ -1,0 +1,19 @@
+variable "api_name" {
+  description = "The API Gateway API name, for associating with the custom domains"
+  type        = string
+}
+
+variable "api_stage" {
+  description = "The stage of the API (e.g. 'dev' or 'prod')"
+  type        = string
+}
+
+variable "certificate_subdomain" {
+  description = "The subdomain for the API Gateway custom domain. Will be combined with the Cloudflare zone (aka domain)."
+  type        = string
+}
+
+variable "cloudflare_zone_name" {
+  description = "The Cloudflare zone (aka domain) name"
+  type        = string
+}

--- a/terraform/modules/api-gateway-domains-and-certs/versions.tf
+++ b/terraform/modules/api-gateway-domains-and-certs/versions.tf
@@ -1,0 +1,16 @@
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      configuration_aliases = [
+        aws.secondary,
+      ]
+    }
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}

--- a/terraform/modules/certificate-and-domain/main.tf
+++ b/terraform/modules/certificate-and-domain/main.tf
@@ -1,0 +1,42 @@
+
+locals {
+  full_domain_name = "${var.certificate_subdomain}.${var.cloudflare_zone_name}"
+}
+
+module "domain" {
+  source     = "../api-gateway-custom-domain"
+  depends_on = [aws_acm_certificate_validation.this]
+
+  api_name        = var.api_name
+  certificate_arn = aws_acm_certificate_validation.this.certificate_arn
+  domain_name     = local.full_domain_name
+  stage           = var.api_stage
+}
+
+
+data "cloudflare_zone" "this" {
+  name = var.cloudflare_zone_name
+}
+
+resource "aws_acm_certificate" "this" {
+  domain_name       = local.full_domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "cloudflare_record" "validation" {
+  count = var.create_dns_validation ? 1 : 0
+
+  name    = tolist(aws_acm_certificate.this.domain_validation_options)[0].resource_record_name
+  value   = tolist(aws_acm_certificate.this.domain_validation_options)[0].resource_record_value
+  type    = tolist(aws_acm_certificate.this.domain_validation_options)[0].resource_record_type
+  zone_id = data.cloudflare_zone.this.id
+  proxied = false
+}
+
+resource "aws_acm_certificate_validation" "this" {
+  certificate_arn = aws_acm_certificate.this.arn
+}

--- a/terraform/modules/certificate-and-domain/outputs.tf
+++ b/terraform/modules/certificate-and-domain/outputs.tf
@@ -1,0 +1,4 @@
+
+output "regional_domain_name" {
+  value = module.domain.regional_domain_name
+}

--- a/terraform/modules/certificate-and-domain/variables.tf
+++ b/terraform/modules/certificate-and-domain/variables.tf
@@ -1,0 +1,26 @@
+
+variable "api_name" {
+  description = "The API Gateway API name, for associating with this custom domain"
+  type        = string
+}
+
+variable "api_stage" {
+  description = "The stage of the API (e.g. 'dev' or 'prod')"
+  type        = string
+}
+
+variable "certificate_subdomain" {
+  description = "The subdomain for the API Gateway custom domain. Will be combined with the Cloudflare zone (aka domain)."
+  type        = string
+}
+
+variable "cloudflare_zone_name" {
+  description = "The Cloudflare zone (aka domain) name for the DNS record for certificate validation."
+  type        = string
+}
+
+variable "create_dns_validation" {
+  description = "Whether to create the DNS record for certificate validation"
+  type        = bool
+  default     = true
+}

--- a/terraform/modules/certificate-and-domain/versions.tf
+++ b/terraform/modules/certificate-and-domain/versions.tf
@@ -1,0 +1,18 @@
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4"
+    }
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+
+      // 4.39.0 and later versions deprecated cloudflare_record.value
+      // constraining to earlier versions while waiting for version 5 to mature
+      version = ">= 2.0.0, < 4.39.0"
+    }
+  }
+}

--- a/terraform/modules/fail-over-cnames/main.tf
+++ b/terraform/modules/fail-over-cnames/main.tf
@@ -1,0 +1,53 @@
+
+locals {
+  primary_region_subdomain   = "${var.subdomain}-${var.aws_region}"
+  secondary_region_subdomain = "${var.subdomain}-${var.aws_region_secondary}"
+
+  primary_region_intermediate_domain   = "${local.primary_region_subdomain}.${var.cloudflare_zone_name}"
+  secondary_region_intermediate_domain = "${local.secondary_region_subdomain}.${var.cloudflare_zone_name}"
+
+  primary_region_summary   = "${var.aws_region}: ${local.primary_region_intermediate_domain}"
+  secondary_region_summary = "${var.aws_region_secondary}: ${local.secondary_region_intermediate_domain}"
+}
+
+data "cloudflare_zone" "this" {
+  name = var.cloudflare_zone_name
+}
+
+// Example: "api.example.com" --> "api-us-east-1.example.com"
+resource "cloudflare_record" "public_cname" {
+  depends_on = [
+    cloudflare_record.primary_region_cname,
+    cloudflare_record.secondary_region_cname
+  ]
+
+  comment = "Public CNAME record. Change this for easy fail over. ${local.primary_region_summary} / ${local.secondary_region_summary}"
+  name    = var.subdomain
+  proxied = var.cloudflare_proxy_status
+  ttl     = 1 # ttl must be set to 1 when proxied is true
+  type    = "CNAME"
+  value   = local.primary_region_intermediate_domain # <-- This controls which region to use by default.
+  zone_id = data.cloudflare_zone.this.id
+}
+
+// Example: "api-us-east-1.example.com" --> "d-abcde12345.execute-api.us-east-1.amazonaws.com"
+resource "cloudflare_record" "primary_region_cname" {
+  comment = "Intermediate CNAME for ${var.aws_region}. DO NOT manually change this."
+  name    = local.primary_region_subdomain
+  proxied = var.cloudflare_proxy_status
+  ttl     = 1 # ttl must be set to 1 when proxied is true
+  type    = "CNAME"
+  value   = var.primary_api_gateway_domain
+  zone_id = data.cloudflare_zone.this.id
+}
+
+// Example: "api-us-west-2.example.com" --> "d-zyxwv67890.execute-api.us-west-2.amazonaws.com"
+resource "cloudflare_record" "secondary_region_cname" {
+  comment = "Intermediate CNAME for ${var.aws_region_secondary}. DO NOT manually change this."
+  name    = local.secondary_region_subdomain
+  proxied = var.cloudflare_proxy_status
+  ttl     = 1 # ttl must be set to 1 when proxied is true
+  type    = "CNAME"
+  value   = var.secondary_api_gateway_domain
+  zone_id = data.cloudflare_zone.this.id
+}

--- a/terraform/modules/fail-over-cnames/outputs.tf
+++ b/terraform/modules/fail-over-cnames/outputs.tf
@@ -1,0 +1,15 @@
+output "primary_region_intermediate_domain" {
+  value = local.primary_region_intermediate_domain
+}
+
+output "primary_region_summary" {
+  value = local.primary_region_summary
+}
+
+output "secondary_region_intermediate_domain" {
+  value = local.secondary_region_intermediate_domain
+}
+
+output "secondary_region_summary" {
+  value = local.secondary_region_summary
+}

--- a/terraform/modules/fail-over-cnames/variables.tf
+++ b/terraform/modules/fail-over-cnames/variables.tf
@@ -1,0 +1,36 @@
+
+variable "aws_region" {
+  description = "The primary AWS region (e.g. us-east-2)"
+  type        = string
+}
+
+variable "aws_region_secondary" {
+  description = "The secondary AWS region (e.g. us-west-2)"
+  type        = string
+}
+
+variable "cloudflare_proxy_status" {
+  description = "Set the Cloudflare CNAME proxy status"
+  type        = bool
+  default     = true
+}
+
+variable "cloudflare_zone_name" {
+  description = "The Cloudflare zone (aka domain) name"
+  type        = string
+}
+
+variable "primary_api_gateway_domain" {
+  description = "The API Gateway primary region's endpoint domain name"
+  type        = string
+}
+
+variable "secondary_api_gateway_domain" {
+  description = "The API Gateway secondary region's endpoint domain name"
+  type        = string
+}
+
+variable "subdomain" {
+  description = "The subdomain for the public CNAME record."
+  type        = string
+}

--- a/terraform/modules/fail-over-cnames/versions.tf
+++ b/terraform/modules/fail-over-cnames/versions.tf
@@ -1,0 +1,14 @@
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+
+      // 4.39.0 and later versions deprecated cloudflare_record.value
+      // constraining to earlier versions while waiting for version 5 to mature
+      version = ">= 2.0.0, < 4.39.0"
+    }
+  }
+}

--- a/terraform/modules/serverless-api-dns-for-failover/README.md
+++ b/terraform/modules/serverless-api-dns-for-failover/README.md
@@ -1,0 +1,11 @@
+# Terraform module for adding DNS-based fail-over capability to a Serverless API
+
+This module sets up custom domain names (with corresponding AWS ACM
+certificates) and a CNAME record (in Cloudflare) for a Serverless Framework
+based API running in AWS Lambda behind API Gateway.
+
+It uses Cloudflare for all DNS records, and it uses regional API Gateway
+endpoints, with a DNS (CNAME) record that can be easily switched to point at
+either AWS region's instance of your Serverless API.
+
+This assumes that your API is running in two AWS regions.

--- a/terraform/modules/serverless-api-dns-for-failover/main.tf
+++ b/terraform/modules/serverless-api-dns-for-failover/main.tf
@@ -1,0 +1,37 @@
+
+locals {
+  aws_region           = data.aws_region.primary.name
+  aws_region_secondary = data.aws_region.secondary.name
+}
+
+data "aws_region" "primary" {}
+
+data "aws_region" "secondary" {
+  provider = aws.secondary
+}
+
+module "api_gateway_domains_and_certs" {
+  source = "../api-gateway-domains-and-certs"
+
+  api_name              = var.api_name
+  api_stage             = var.serverless_stage
+  certificate_subdomain = var.subdomain
+  cloudflare_zone_name  = var.cloudflare_zone_name
+
+  providers = {
+    aws           = aws
+    aws.secondary = aws.secondary
+  }
+}
+
+module "fail_over_cnames" {
+  source = "../fail-over-cnames"
+
+  aws_region                   = local.aws_region
+  aws_region_secondary         = local.aws_region_secondary
+  cloudflare_proxy_status      = var.cloudflare_proxy_status
+  cloudflare_zone_name         = var.cloudflare_zone_name
+  primary_api_gateway_domain   = module.api_gateway_domains_and_certs.primary_api_gateway_domain
+  secondary_api_gateway_domain = module.api_gateway_domains_and_certs.secondary_api_gateway_domain
+  subdomain                    = var.subdomain
+}

--- a/terraform/modules/serverless-api-dns-for-failover/outputs.tf
+++ b/terraform/modules/serverless-api-dns-for-failover/outputs.tf
@@ -1,0 +1,16 @@
+
+output "primary_region_domain_name" {
+  value = module.fail_over_cnames.primary_region_intermediate_domain
+}
+
+output "primary_region_summary" {
+  value = module.fail_over_cnames.primary_region_summary
+}
+
+output "secondary_region_domain_name" {
+  value = module.fail_over_cnames.secondary_region_intermediate_domain
+}
+
+output "secondary_region_summary" {
+  value = module.fail_over_cnames.secondary_region_summary
+}

--- a/terraform/modules/serverless-api-dns-for-failover/variables.tf
+++ b/terraform/modules/serverless-api-dns-for-failover/variables.tf
@@ -1,0 +1,26 @@
+
+variable "api_name" {
+  description = "Short name of the API (as shown in AWS API Gateway). It probably consists of your Serverless service name and stage (e.g. either 'my-api-dev' or 'dev-my-api')."
+  type        = string
+}
+
+variable "cloudflare_proxy_status" {
+  description = "Set the Cloudflare CNAME proxy status"
+  type        = bool
+  default     = true
+}
+
+variable "cloudflare_zone_name" {
+  description = "Cloudflare zone (aka domain) name"
+  type        = string
+}
+
+variable "serverless_stage" {
+  description = "Short name for the stage (aka environment): 'dev' or 'prod'"
+  type        = string
+}
+
+variable "subdomain" {
+  description = "The subdomain for the public CNAME record (e.g. 'my-api')"
+  type        = string
+}

--- a/terraform/modules/serverless-api-dns-for-failover/versions.tf
+++ b/terraform/modules/serverless-api-dns-for-failover/versions.tf
@@ -1,0 +1,16 @@
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      configuration_aliases = [
+        aws.secondary,
+      ]
+    }
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}


### PR DESCRIPTION
[ITSE-2706](https://support.gtis.sil.org/issue/ITSE-2706) Update Terraform AWS provider to 6.x

---

### Changed
- In preparation for upgrading Terraform providers, this pull request copies module configuration files into this repository. None of these modules are used in any of our other projects. No code has been changed other than module `source` references and removal of `moved` blocks.