### PR TITLE
add variables to allow for deploying from any GitHub account

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,7 +9,7 @@ data "aws_caller_identity" "this" {}
 # Role for CDK deployment and CI/CD alerts using SES
 
 resource "aws_iam_role" "cd" {
-  description = "for GitHub Actions in sil-org/serverless-mfa-api-go to send SES email alerts"
+  description = "for GitHub Actions to deploy app with CDK and to send email alerts with SES"
   name        = "${var.app_name}-${var.app_env}-cd"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -18,14 +18,14 @@ resource "aws_iam_role" "cd" {
       Effect = "Allow"
       Action = "sts:AssumeRoleWithWebIdentity"
       Principal = {
-        Federated = data.tfe_outputs.appsdev_aws_account_silidp.nonsensitive_values.github_oidc_provider_arn
+        Federated = var.github_oidc_provider_arn
       }
       Condition = {
         StringEquals = {
           "token.actions.githubusercontent.com:aud" : "sts.amazonaws.com"
         },
         StringLike = {
-          "token.actions.githubusercontent.com:sub" : "repo:sil-org/serverless-mfa-api-go:*"
+          "token.actions.githubusercontent.com:sub" : "repo:${var.github_repository}:*"
         }
       }
     }]
@@ -48,8 +48,8 @@ resource "aws_iam_role_policy" "cd" {
         Sid       = "SendEmailAlerts"
         Effect    = "Allow"
         Action    = ["ses:SendEmail"]
-        Resource  = data.tfe_outputs.appsdev_aws_account_silidp.nonsensitive_values.ses_domain_identity_us_east_1_arn,
-        Condition = { StringEquals = { "ses:FromAddress" = "no_reply@ses.iidp.net" } }
+        Resource  = var.ses_domain_identity_arn,
+        Condition = { StringEquals = { "ses:FromAddress" = var.alerts_email } }
       },
     ]
   })
@@ -239,9 +239,4 @@ resource "aws_dynamodb_table" "webauthn" {
   lifecycle {
     ignore_changes = [replica]
   }
-}
-
-data "tfe_outputs" "appsdev_aws_account_silidp" {
-  organization = "gtis"
-  workspace    = "appsdev-aws-account-silidp"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -60,3 +60,36 @@ variable "app_name_tag" {
   type        = string
   default     = "idp"
 }
+
+/*
+ * GitHub OIDC authorization
+ */
+
+variable "github_oidc_provider_arn" {
+  description = <<-EOT
+    ARN of the OIDC provider for GitHub in AWS IAM, used for GitHub Actions to authenticate to AWS. The provider
+    can be created in Terraform using the `aws_iam_openid_connect_provider` resource. Specify the URL as
+    "https://token.actions.githubusercontent.com" and the client_id_list as ["sts.amazonaws.com"].
+  EOT
+  type        = string
+}
+
+variable "github_repository" {
+  description = <<-EOT
+    GitHub repository that should be granted access to the OIDC provider for GitHub. Format should be 'owner/repo'.
+  EOT
+  type        = string
+}
+
+/*
+ * SES configuration for alerts
+ */
+
+variable "ses_domain_identity_arn" {
+  description = "ARN of the SES domain identity to use for sending email alerts"
+  type        = string
+}
+variable "alerts_email" {
+  description = "Email address to use for sending alerts"
+  type        = string
+}


### PR DESCRIPTION
[IDP-2161](https://support.gtis.sil.org/issue/IDP-2161) Plan moving Wycliffe's 2SV data

---

### Added
- Replaced Terraform Cloud references with new variables:
  - `github_oidc_provider_arn`
  - `github_repository`
  - `ses_domain_identity_arn`
  - `alerts_email`